### PR TITLE
Version update to resolve security issue in github.com/jinzhu/gorm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/google/gops v0.3.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
-	github.com/jinzhu/gorm v1.9.2
+	github.com/jinzhu/gorm v1.9.10
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
 	github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3 // indirect
 	github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7


### PR DESCRIPTION
github.com/jinzhu/gorm is vulnerable so suggesting to upgrade the version to a secured one. You can check module vulnerability here : 

https://search.gocenter.io/github.com~2Fjinzhu~2Fgorm/info?version=v1.9.2


CVE-2019-15562
GORM before 1.9.10 allows SQL injection via incomplete parentheses. 
